### PR TITLE
Upgrade to .Net Standard 2.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # DataProtection.Postgres Toolbox
 
+## 3.0.0
+
+- upgrade to .Net Standard 2.0 for compatibility with .Net Core 2.0 web projects
+
 ## 2.0.0
 
 - conversion to csproj en MSBuild.

--- a/src/Digipolis.DataProtection.Postgres/Digipolis.DataProtection.Postgres.csproj
+++ b/src/Digipolis.DataProtection.Postgres/Digipolis.DataProtection.Postgres.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>3.0.0</VersionPrefix>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Digipolis.DataProtection.Postgres</AssemblyName>
     <PackageId>Digipolis.DataProtection.Postgres</PackageId>

--- a/src/Digipolis.DataProtection.Postgres/Digipolis.DataProtection.Postgres.csproj
+++ b/src/Digipolis.DataProtection.Postgres/Digipolis.DataProtection.Postgres.csproj
@@ -2,20 +2,24 @@
 
   <PropertyGroup>
     <VersionPrefix>2.0.0</VersionPrefix>
-    <TargetFramework>netstandard1.6</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Digipolis.DataProtection.Postgres</AssemblyName>
     <PackageId>Digipolis.DataProtection.Postgres</PackageId>
-    <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
-    <PackageTargetFallback>$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
+    <NetStandardImplicitPackageVersion>2.0</NetStandardImplicitPackageVersion>
+    <AssetTargetFallback>$(AssetTargetFallback);dnxcore50</AssetTargetFallback>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="1.0.2" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="1.0.2" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="1.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.0.0" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="2.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Digipolis.Dataprotection.Postgres.Migrations\Digipolis.Dataprotection.Postgres.Migrations.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Digipolis.Dataprotection.Postgres.Migrations/DataContextFactory.cs
+++ b/src/Digipolis.Dataprotection.Postgres.Migrations/DataContextFactory.cs
@@ -1,5 +1,6 @@
 ﻿using Digipolis.DataProtection.Postgres;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using System;
 using System.Collections.Generic;
@@ -8,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace Digipolis.Dataprotection.Postgres.Migrations
 {
-    internal class DataContextFactory : IDbContextFactory<DataContext>
+    internal class DataContextFactory : IDesignTimeDbContextFactory<DataContext>
     {
         private readonly string _connectionString;
 
@@ -24,6 +25,11 @@ namespace Digipolis.Dataprotection.Postgres.Migrations
             var dbContextOptions = builder.Options;
 
             return new DataContext(dbContextOptions);
+        }
+
+        public DataContext CreateDbContext(string[] args)
+        {
+            return Create(null);
         }
     }
 }

--- a/src/Digipolis.Dataprotection.Postgres.Migrations/Digipolis.Dataprotection.Postgres.Migrations.csproj
+++ b/src/Digipolis.Dataprotection.Postgres.Migrations/Digipolis.Dataprotection.Postgres.Migrations.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Digipolis.Dataprotection.Postgres.Migrations</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>Digipolis.Dataprotection.Postgres.Migrations</PackageId>
-    <RuntimeFrameworkVersion>1.1.1</RuntimeFrameworkVersion>
-    <PackageTargetFallback>$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
+    <RuntimeFrameworkVersion>2.0</RuntimeFrameworkVersion>
+    <AssetTargetFallback>$(AssetTargetFallback);dnxcore50</AssetTargetFallback>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -17,14 +17,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="1.0.3">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.0.0">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="1.0.0" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.EntityFrameworkCore.Tools.DotNet" Version="1.0.0" />
+    <DotNetCliToolReference Include="Microsoft.EntityFrameworkCore.Tools.DotNet" Version="2.0.0" />
   </ItemGroup>
 
 </Project>

--- a/test/Digipolis.DataProtection.Tests/Digipolis.DataProtection.Tests.csproj
+++ b/test/Digipolis.DataProtection.Tests/Digipolis.DataProtection.Tests.csproj
@@ -3,13 +3,13 @@
   <PropertyGroup>
     <Description>Digipolis.DataProtection.Postgres unit tests.</Description>
     <Authors>digipolis.be</Authors>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>Digipolis.DataProtection.Tests</AssemblyName>
     <PackageId>Digipolis.DataProtection.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
-    <PackageTargetFallback>$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
-    <RuntimeFrameworkVersion>1.1.1</RuntimeFrameworkVersion>
+    <NetStandardImplicitPackageVersion>2.0</NetStandardImplicitPackageVersion>
+    <AssetTargetFallback>$(AssetTargetFallback);dnxcore50</AssetTargetFallback>
+    <RuntimeFrameworkVersion>2.0</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -24,12 +24,16 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="moq.netcore" Version="4.4.0-beta8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="1.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="1.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta1-build3642" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Collega
Omwille van de (redelijk) recente upgrade van de starterskit voor web projecten naar .Net Core 2.0 is er een dependency probleem ontstaan ter hoogte van deze toolbox als de optie om de dotnetkeystore te gebruiken, aangeschakeld wordt in het web project.
Het probleem zat hem in de EntityFrameworkCore dependency die gebruikt werd om de communicatie te doen met de postgres database. Deze diende een upgrade te krijgen naar versie 2.0.0.
Hierdoor heb ik ook een wijziging moeten doen in het project voor de migraties. Namelijk in de DataContextFactory. IDbContextFactory is ondertussen deprecated en diende vervangen te worden door IDesignTimeDbContextFactory. Hierdoor heb ik wel een nieuwe methode moeten implementeren die verplicht werd vanuit de nieuwe interface. Deze heb ik echter de bestaande create methode laten aanroepen.
In afwachting van de goedkeuring voor deze pull request, heb ik de nodige projecten lokaal in het project VrijwilligeOppas getrokken en gereferenced. Dit project maakt op dit moment dus geen gebruik meer van de authentication tooblox die op de nexus gepublished is.
**Opgelet:** hoogstwaarschijnlijk dient ook hier een ontdubbeling te gebeuren van de authentication toolbox te gebeuren zodat oudere projecten hier geen problemen van ondervinden.
Mvg
Jeroen Desmet